### PR TITLE
Update gclound-node to use resumable upload

### DIFF
--- a/lib/mongobq.js
+++ b/lib/mongobq.js
@@ -138,7 +138,10 @@ MongoBQ.prototype.uploadToGCS = function (next) {
     if (self.opts.compress) {
       stream = stream.pipe(zlib.createGzip());
     }
-    stream.pipe(self.file().createWriteStream()).on('finish', onEnd);
+    stream
+      .pipe(self.file().createWriteStream())
+      .on('error', next)
+      .on('finish', onEnd);
   }
 };
 

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "async": "^0.9.0",
     "commander": "^2.5.0",
-    "gcloud": "^0.11.0",
+    "gcloud": "GoogleCloudPlatform/gcloud-node",
     "moment": "^2.8.4",
     "mongodb": "^2.0.9",
     "through2": "^0.6.3",


### PR DESCRIPTION
Current release version of gcloud-node 0.11.0 is not supported resumable upload. So use master branch on github for now. After release new version of gcloud-node, I'll upload dependencies.
