### PR TITLE
Change code caused gcloud-node change

### DIFF
--- a/lib/mongobq.js
+++ b/lib/mongobq.js
@@ -163,7 +163,10 @@ MongoBQ.prototype.importIntoBigQuery = function (schema, next) {
   console.log();
 
   if (this.opts.dryrun) return next(null, null);
-  this.table().load(this.file(), loadConfig, next);
+  this.table().load(this.file(), loadConfig, function (err, job, apiResponse) {
+    if (err) return next(err);
+    next(null, job);
+  });
 };
 
 MongoBQ.prototype.waitLoadJob = function (job, next) {
@@ -212,9 +215,9 @@ function handleJobResult(metadata) {
     console.log('Failure deitals:');
     status.errors.forEach(function (err) {
       if (err.location) {
-        console.log(' - %s: %s', err.location, err.message);
+        console.log('%s - line %s: %s', err.reason, err.location, err.message);
       } else {
-        console.log(err.message);
+        console.log('%s: %s', err.reason, err.message);
       }
     });
   } else {


### PR DESCRIPTION
Callback method of `table.import()` argument count is changed at https://github.com/GoogleCloudPlatform/gcloud-node/commit/b1af0d07012a97039d8984a0ded3c9bc8749c49b.

