### PR TITLE
[Breaking Change] Update gcloud and mongodb

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: node_js
 node_js:
-  - "0.10"
-  - "0.12"
+  - 0.12
+  - 4
+  - 6
 sudo: false

--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 `mongobq` is a command line tool to import MongoDB collection into BigQuery.
 
+mongobq >= 0.2.0 only works with node >= 0.12.0.
+You want to use with node 0.10 or below, use 0.1.4.
+
 ## Usage
 
 ```

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mongobq",
   "description": "Command line tool to import MongoDB collection into BigQuery",
-  "version": "0.1.4",
+  "version": "0.2.0",
   "author": "Kazuyuki Honda <hakobera@gmail.com>",
   "bin": "./bin/mongobq",
   "bugs": {
@@ -10,9 +10,9 @@
   "dependencies": {
     "async": "^0.9.0",
     "commander": "^2.5.0",
-    "gcloud": "^0.17.0",
+    "gcloud": "^0.33.0",
     "moment": "^2.8.4",
-    "mongodb": "^2.0.40",
+    "mongodb": "^2.1.19",
     "through2": "^0.6.5",
     "underscore": "^1.7.0"
   },
@@ -23,7 +23,7 @@
     "should": "^4.3.0"
   },
   "engines": {
-    "node": ">= 0.10.0"
+    "node": ">= 0.12.0"
   },
   "files": [
     "bin/",


### PR DESCRIPTION
Latest `gcloud` only support >= 0.12.0, so after this change `mongobq` can only run with node >= 0.12.0