### PR TITLE
Use global regex for safename replacement

### DIFF
--- a/lib/gcp.js
+++ b/lib/gcp.js
@@ -19,7 +19,7 @@ function GCP(opts) {
 }
 
 GCP.safeName = function (name) {
-  var n = name.replace(/\W/, '_').toLowerCase();
+  var n = name.replace(/\W/g, '_').toLowerCase();
   if (n.charAt(0) === '_') {
     n = n.substr(1);
   }


### PR DESCRIPTION
Noticed that something like `X-ABCD-efgh` only converted the first underscore to `x_abcd-efgh`. This PR changes the regex so the replacement is global.
