### PR TITLE
Pass in fields as json instead of comma delimited list.

### DIFF
--- a/bin/mongobq
+++ b/bin/mongobq
@@ -14,7 +14,7 @@ program
   .option('-p, --password <password>', 'specifies a mongodb password to authenticate')
   .option('-d, --database <database>', 'specifies the name of the database')
   .option('-c, --collection <collection>', 'specifies the collection to export')
-  .option('-f, --fields <field1[,field2]>', 'specifies a field or fields to include in the export')
+  .option('-f, --fields <JSON>', 'specifies a field or fields to include in the export', JSON.parse)
   .option('-q, --query <JSON>', 'provides a JSON document as a query that optionally limits the documents returned in the export', JSON.parse)
   .option('-K, --keyfile <keyfile>', 'specifies the key file path')
   .option('-B, --bucket <bucket>', 'specifies the Google Cloud Storage bucket name')
@@ -41,7 +41,7 @@ var opts = {
   username: program.username,
   password: program.password,
   query: program.query || {},
-  fields: parseFields(program.schema, program.fields),
+  fields: program.fields,
   project: program.project,
   keyfile: program.keyfile,
   bucket: program.bucket,

--- a/lib/mongo.js
+++ b/lib/mongo.js
@@ -30,7 +30,7 @@ function Mongo(opts) {
   this.mongodbUri = buildMongodbUri(opts);
   this.collection = opts.collection;
   this.query = opts.query || {};
-  this.fields = buildField(opts.fields);
+  this.fields = opts.fields;
   this.limit = opts.limit;
   this.skip = opts.skip;
   this.db = null;

--- a/lib/mongobq.js
+++ b/lib/mongobq.js
@@ -99,7 +99,7 @@ MongoBQ.prototype.uploadToGCS = function (next) {
   var count = 0;
   var autoSchemaDetection = !self.opts.schema;
   var schema = self.opts.schema || [];
-  var fields = self.opts.fields || [];
+  var fields = self.opts.fields;
   var stream = self.mongo.stream(self.opts.batchSize)
                 .pipe(GCP.BigQueryTable.createJSONStream(schema, autoSchemaDetection))
                 .on('data', function (d) { count++; })


### PR DESCRIPTION
You probably don't want to merge this but I thought I'd pr it anyway.

This allows for blacklisting fields rather than only white listing, and in general just passes through to the mongo library.

It does not maintain the previous interplay between a passed in schema and the passed in fields.